### PR TITLE
Add Revit test runner skeleton

### DIFF
--- a/NugetMcpCli.sln
+++ b/NugetMcpCli.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPackage", "TestPackage\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NugetMcpCli.Tests", "NugetMcpCli.Tests\NugetMcpCli.Tests.csproj", "{D9618D20-86CD-4512-80BE-31EA136BA170}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitAddin", "RevitAddin\RevitAddin.csproj", "{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{D9618D20-86CD-4512-80BE-31EA136BA170}.Release|x64.Build.0 = Release|Any CPU
 		{D9618D20-86CD-4512-80BE-31EA136BA170}.Release|x86.ActiveCfg = Release|Any CPU
 		{D9618D20-86CD-4512-80BE-31EA136BA170}.Release|x86.Build.0 = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|x64.Build.0 = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8E0FFCB-080C-497C-A7C3-09CB45E03E4D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RevitAddin/PipeClient.cs
+++ b/RevitAddin/PipeClient.cs
@@ -1,0 +1,30 @@
+using System.IO.Pipes;
+using System.IO;
+using System.Text.Json;
+
+namespace RevitAddin
+{
+    public static class PipeClient
+    {
+        private const string PipeName = "RevitTestPipe";
+
+        public static PipeMessage? WaitForMessage()
+        {
+            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.InOut);
+            client.Connect();
+            using var reader = new StreamReader(client);
+            var line = reader.ReadLine();
+            if (line == null)
+                return null;
+            return JsonSerializer.Deserialize<PipeMessage>(line);
+        }
+
+        public static void SendResult(string resultPath)
+        {
+            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.InOut);
+            client.Connect();
+            using var writer = new StreamWriter(client) { AutoFlush = true };
+            writer.WriteLine(resultPath);
+        }
+    }
+}

--- a/RevitAddin/PipeMessages.cs
+++ b/RevitAddin/PipeMessages.cs
@@ -1,0 +1,9 @@
+namespace RevitAddin
+{
+    public class PipeMessage
+    {
+        public string Command { get; set; } = string.Empty;
+        public string TestAssembly { get; set; } = string.Empty;
+        public string[]? TestMethods { get; set; }
+    }
+}

--- a/RevitAddin/RevitAddin.csproj
+++ b/RevitAddin/RevitAddin.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Engine" Version="3.17.1" />
+  </ItemGroup>
+</Project>

--- a/RevitAddin/RevitNUnitExecutor.cs
+++ b/RevitAddin/RevitNUnitExecutor.cs
@@ -1,0 +1,22 @@
+using Autodesk.Revit.UI;
+using NUnit.Engine;
+using System.IO;
+
+namespace RevitAddin
+{
+    public static class RevitNUnitExecutor
+    {
+        public static string ExecuteTestsInRevit(string testAssemblyPath, UIApplication uiApp)
+        {
+            using var engine = TestEngineActivator.CreateInstance();
+            var package = new TestPackage(testAssemblyPath);
+            var runner = engine.GetRunner(package);
+            var result = runner.Run(null, TestFilter.Empty);
+
+            string resultXml = result.OuterXml;
+            var resultsPath = Path.Combine(Path.GetTempPath(), "RevitTestResults.xml");
+            File.WriteAllText(resultsPath, resultXml);
+            return resultsPath;
+        }
+    }
+}

--- a/RevitAddin/RevitStub.cs
+++ b/RevitAddin/RevitStub.cs
@@ -1,0 +1,26 @@
+namespace Autodesk.Revit.UI
+{
+    public class UIApplication
+    {
+        public object ControlledApplication { get; }
+        public UIApplication(object app) => ControlledApplication = app;
+    }
+
+    public interface IExternalApplication
+    {
+        Autodesk.Revit.UI.Result OnStartup(UIControlledApplication application);
+        Autodesk.Revit.UI.Result OnShutdown(UIControlledApplication application);
+    }
+
+    public class UIControlledApplication
+    {
+        public object ControlledApplication { get; } = new object();
+    }
+
+    public enum Result { Succeeded, Failed, Cancelled }
+}
+
+namespace Autodesk.Revit.DB
+{
+    public class Document { }
+}

--- a/RevitAddin/RevitTestApp.cs
+++ b/RevitAddin/RevitTestApp.cs
@@ -1,0 +1,25 @@
+using Autodesk.Revit.UI;
+using Autodesk.Revit.DB;
+
+namespace RevitAddin
+{
+    public class RevitTestApp : IExternalApplication
+    {
+        public Result OnStartup(UIControlledApplication application)
+        {
+            var msg = PipeClient.WaitForMessage();
+            if (msg != null && msg.Command == "RunTests")
+            {
+                var uiapp = new UIApplication(application.ControlledApplication);
+                var resultPath = RevitNUnitExecutor.ExecuteTestsInRevit(msg.TestAssembly, uiapp);
+                PipeClient.SendResult(resultPath);
+            }
+            return Result.Succeeded;
+        }
+
+        public Result OnShutdown(UIControlledApplication application)
+        {
+            return Result.Succeeded;
+        }
+    }
+}

--- a/RevitAddin/RevitTestModelAttribute.cs
+++ b/RevitAddin/RevitTestModelAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace RevitAddin
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class RevitTestModelAttribute : Attribute
+    {
+        public string ProjectGuid { get; }
+        public string ModelGuid { get; }
+
+        public RevitTestModelAttribute(string projectGuid, string modelGuid)
+        {
+            ProjectGuid = projectGuid;
+            ModelGuid = modelGuid;
+        }
+    }
+}

--- a/RevitTestAdapter/NUnit3TestResultParser.cs
+++ b/RevitTestAdapter/NUnit3TestResultParser.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace RevitTestAdapter
+{
+    internal class NUnit3TestResultParser
+    {
+        public IEnumerable<TestResult> Parse(string resultXmlPath, string assembly)
+        {
+            var doc = XDocument.Load(resultXmlPath);
+            var testCases = doc.Descendants("test-case");
+            foreach (var test in testCases)
+            {
+                var name = test.Attribute("fullname")!.Value;
+                var outcome = test.Attribute("result")!.Value;
+                var duration = double.Parse(test.Attribute("duration")!.Value);
+                var tc = new TestCase(name, new System.Uri("executor://RevitTestExecutor"), assembly);
+                var tr = new TestResult(tc)
+                {
+                    Duration = System.TimeSpan.FromSeconds(duration),
+                    Outcome = outcome == "Passed" ? TestOutcome.Passed : outcome == "Failed" ? TestOutcome.Failed : TestOutcome.Skipped
+                };
+                if (outcome == "Failed")
+                {
+                    tr.ErrorMessage = test.Element("failure")?.Element("message")?.Value;
+                    tr.ErrorStackTrace = test.Element("failure")?.Element("stack-trace")?.Value;
+                }
+                yield return tr;
+            }
+        }
+    }
+}

--- a/RevitTestAdapter/RevitTestAdapter.csproj
+++ b/RevitTestAdapter/RevitTestAdapter.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.9.0" />
+  </ItemGroup>
+</Project>

--- a/RevitTestAdapter/RevitTestDiscoverer.cs
+++ b/RevitTestAdapter/RevitTestDiscoverer.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System.Collections.Generic;
+
+namespace RevitTestAdapter
+{
+    [FileExtension(".dll")]
+    [DefaultExecutorUri("executor://RevitTestExecutor")]
+    public class RevitTestDiscoverer : ITestDiscoverer
+    {
+        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        {
+            // Simple reflection-based discovery for sample purposes
+            foreach (var source in sources)
+            {
+                var asm = System.Reflection.Assembly.LoadFrom(source);
+                foreach (var type in asm.GetTypes())
+                {
+                    foreach (var method in type.GetMethods())
+                    {
+                        if (method.GetCustomAttributes(typeof(NUnit.Framework.TestAttribute), true).Length > 0)
+                        {
+                            var tc = new TestCase($"{type.FullName}.{method.Name}", new System.Uri("executor://RevitTestExecutor"), source);
+                            discoverySink.SendTestCase(tc);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RevitTestAdapter/RevitTestExecutor.cs
+++ b/RevitTestAdapter/RevitTestExecutor.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Text.Json;
+
+namespace RevitTestAdapter
+{
+    [ExtensionUri("executor://RevitTestExecutor")]
+    public class RevitTestExecutor : ITestExecutor
+    {
+        private const string PipeName = "RevitTestPipe";
+
+        public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            var testList = new List<string>();
+            foreach (var t in tests)
+                testList.Add(t.FullyQualifiedName);
+            RunInRevit(tests.First().Source!, testList, frameworkHandle);
+        }
+
+        public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            foreach (var src in sources)
+                RunInRevit(src, null, frameworkHandle);
+        }
+
+        private static void RunInRevit(string assembly, List<string>? tests, IFrameworkHandle handle)
+        {
+            using var server = new NamedPipeServerStream(PipeName, PipeDirection.InOut, 1);
+            var psi = new ProcessStartInfo
+            {
+                FileName = "revit.exe",
+                Arguments = $"/addin:\"{assembly}\"",
+            };
+            Process.Start(psi);
+            server.WaitForConnection();
+            using var writer = new StreamWriter(server) { AutoFlush = true };
+            var msg = JsonSerializer.Serialize(new { Command = "RunTests", TestAssembly = assembly, TestMethods = tests });
+            writer.WriteLine(msg);
+            using var reader = new StreamReader(server);
+            var resultPath = reader.ReadLine();
+            if (!string.IsNullOrEmpty(resultPath))
+            {
+                var parser = new NUnit3TestResultParser();
+                foreach (var result in parser.Parse(resultPath!, assembly))
+                    handle.RecordResult(result);
+            }
+        }
+
+        public void Cancel() { }
+    }
+}


### PR DESCRIPTION
## Summary
- add Revit add-in project with NUnit executor
- include named pipe communication helpers
- stub minimal Revit API classes
- add Visual Studio test adapter skeleton
- update solution with the new RevitAddin project

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685f25e4478c8326b54d3e732931b98d